### PR TITLE
SplashScreen that support for Android 12.

### DIFF
--- a/Interview_Prep_App/native_kotlin/retrofit/build.gradle
+++ b/Interview_Prep_App/native_kotlin/retrofit/build.gradle
@@ -66,4 +66,7 @@ dependencies {
     //Retrofit with Moshi converter
     implementation "com.squareup.retrofit2:converter-moshi:2.9.0"
     implementation 'com.google.android.material:material:1.7.0'
+
+    // Splashscreen
+    implementation("androidx.core:core-splashscreen:1.0.0")
 }

--- a/Interview_Prep_App/native_kotlin/retrofit/src/main/AndroidManifest.xml
+++ b/Interview_Prep_App/native_kotlin/retrofit/src/main/AndroidManifest.xml
@@ -8,9 +8,9 @@
     <application
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
-        android:theme="@style/AppTheme">
-        <activity
-            android:name=".ui.splash_screen.SplashScreenActivity"
+        android:theme="@style/Theme.AppSplash">
+    <activity
+            android:name=".ui.main.MainActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -19,7 +19,7 @@
             </intent-filter>
         </activity>
         <activity
-            android:name=".ui.main.MainActivity"
+            android:name=".ui.splash_screen.SplashScreenActivity"
             android:exported="true">
 
         </activity>

--- a/Interview_Prep_App/native_kotlin/retrofit/src/main/java/com/interviewprep/kotlinretrofit/ui/main/MainActivity.kt
+++ b/Interview_Prep_App/native_kotlin/retrofit/src/main/java/com/interviewprep/kotlinretrofit/ui/main/MainActivity.kt
@@ -53,6 +53,8 @@ class MainActivity : AppCompatActivity(), OnFragmentInteractionListener {
     private var score = 0.0
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        installSplashScreen()
+
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 

--- a/Interview_Prep_App/native_kotlin/retrofit/src/main/res/values/splash_theme.xml
+++ b/Interview_Prep_App/native_kotlin/retrofit/src/main/res/values/splash_theme.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <!-- Splash Screen Theme. -->
+    <style name="Theme.AppSplash" parent="Theme.SplashScreen">
+        <item name="windowSplashScreenBackground">@color/white</item>
+        <item name="windowSplashScreenAnimatedIcon">@mipmap/ic_logo_foreground</item>
+        <item name="windowSplashScreenAnimationDuration">2000</item>
+        <item name="postSplashScreenTheme">@style/Theme.AppTheme</item>
+
+        <!-- Status bar and Nav bar configs -->
+        <item name="android:statusBarColor" tools:targetApi="l">@color/white</item>
+        <item name="android:navigationBarColor">@color/white</item>
+<!--        if your minimum API is 26, uncomment the following code to provide lightStatusBar-->
+<!--        <item name="android:windowLightStatusBar">true</item>-->
+    </style>
+</resources>
+<!--<a href="https://www.freepik.com/free-vector/taking-notes-concept-illustration_7069574.htm#query=interview&position=4&from_view=search&track=sph#page=1&query=i&from_query=undefined&position=0&from_view=search&track=sph">Image by storyset</a> on Freepik-->


### PR DESCRIPTION
## What type of PR is this? (check all applicable)


- [ ] 🚀 Added Name
- [x] ✨ Feature
- [x] 🌟 stared the repo
- [ ] 🐛 Grammatical Error
- [ ] 📝 Documentation Update
- [ ] 🚩 Other

## Description
I added SplashScreen feature using best practice that support for Android 12.

## Add Link of GitHub Profile
https://github.com/Rarj/Hacktoberfest_Interview_App

## Screenshot
Tested on Android Q (API 29)

<img src="https://user-images.githubusercontent.com/23600466/197782430-5b200260-3edc-4fd1-9167-8092b2bae779.png" width="240" height="480">


## Attribute Image
<a href="https://www.freepik.com/free-vector/taking-notes-concept-illustration_7069574.htm#query=interview&position=4&from_view=search&track=sph#page=1&query=i&from_query=undefined&position=0&from_view=search&track=sph">Image by storyset</a> on Freepik


